### PR TITLE
Correct url when reloading form after component change

### DIFF
--- a/js/modform.js
+++ b/js/modform.js
@@ -19,7 +19,7 @@ function type_change_submit(advicetext, courseid, section, returntomod, sesskey)
 		if (!typeselobj){
 			typeselobj = document.getElementById('menulabelclass');
 		}
-        url = '/course/mod.php?id='+courseid+'&section='+section+'&sesskey='+sesskey+'&add=customlabel&returntomod='+returntomod+'&type='+ typeselobj.options[typeselobj.selectedIndex].value;
+        url = './mod.php?id='+courseid+'&section='+section+'&sesskey='+sesskey+'&add=customlabel&returntomod='+returntomod+'&type='+ typeselobj.options[typeselobj.selectedIndex].value;
         document.location.href = url;
 	}
 }


### PR DESCRIPTION
Fix to make form reload correctly when installation not at root of server. 

Previously
http://127.0.0.1/moodle24/course/modedit.php?add=customlabel...
would reload as 
http://127.0.0.1/course/modedit.php?add=customlabel...
